### PR TITLE
Change expired date text color in Charts available dialog. 

### DIFF
--- a/src/oesenc_pi.cpp
+++ b/src/oesenc_pi.cpp
@@ -5096,7 +5096,12 @@ void showChartinfoDialog( void )
             hdr += _T("<td>") + token + _T("</td>");
             
             token = tkx.GetNextToken();         // expiry date
-            hdr += _T("<td><font color=#ff0000>") + token + _T("</font></td>");
+            wxDateTime exdate;
+            exdate.ParseDate(token);
+            wxTimeSpan diff = exdate - wxDateTime::Today();
+            // Expired? Red text
+            hdr += diff > 0 ? _T("<td>") + token + _T("</td>") :
+                              _T("<td><font color=#ff0000>") + token + _T("</font></td>");            
         }
         
         hdr += _T("</tr>");


### PR DESCRIPTION
Change the somewhat annoying red expired dates to black but switch to red color if a chart set actually is expired. 
Hopefully we haven't promised HO's to keep them red all the time?

![oeSENC_validation](https://user-images.githubusercontent.com/7202854/54233769-f04d4d00-450d-11e9-8b92-c68298b3d84b.PNG)

