### PR TITLE
Do not override CMAKE_INSTALL_PREFIX if PREFIX not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,6 @@ IF (NOT WIN32)
   # default
   SET (ARCH "i386")
   IF (UNIX AND NOT APPLE)
-    IF (PREFIX)
-        SET(CMAKE_INSTALL_PREFIX ${PREFIX})
-    ELSE (PREFIX )
-        SET(CMAKE_INSTALL_PREFIX "/usr")
-    ENDIF (PREFIX)
 
     MESSAGE (STATUS "*** Will install to ${CMAKE_INSTALL_PREFIX}  ***")
 


### PR DESCRIPTION
If `PREFIX` is set, `CMAKE_INSTALL_PREFIX` is already modified by https://github.com/bdbcat/oesenc_pi/blob/master/CMakeLists.txt#L43, setting it to `/bin` by default is wrong and not in line with what is used everywhere else.

This should not be an issue for packaging neither as debhelper sets `CMAKE_INSTALL_PREFIX` to `/bin` automagically when it packages a cmake project on Launchpad.