### PR TITLE
flatpak: Update to libusb-0.1.12 + debian patches.

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
@@ -7,13 +7,28 @@ separate-locales: false
 appstream-compose: false
 modules:
     - name: libusb
-      no-autogen: true
       sources:
           - type: archive
-            url: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/0.1.6/libusb-0.1.6.tar.gz
-            sha256: 0bafb64bfc41da07ba24c80ee86f57d43c15334e6ff593f806fc331ff8a19571
-      make-install-args:
-          - prefix=/app/extensions/oesenc
+            url: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/0.1.12/libusb-0.1.12.tar.gz
+            sha256: 37f6f7d9de74196eb5fc0bbe0aea9b5c939de7f500acba3af6fd643f3b538b44
+          - type: patch
+            paths:
+                - patches/0001-debian-patch-00-packed.diff.patch
+                - patches/0002-debian-patch-01-ansi.diff.patch
+                - patches/0003-debian-patch-02-usbpp.diff.patch
+                - patches/0004-debian-patch-03-const-buffers.diff.patch
+                - patches/0005-debian-patch-04-infinite-loop.diff.patch
+                - patches/0006-debian-patch-05-emdebian_libs.diff.patch
+                - patches/0007-debian-patch-06-bsd.diff.patch
+                - patches/0008-debian-patch-07-altsetting_alloc.diff.patch
+                - patches/0009-debian-patch-08-bus_location.diff.patch
+                - patches/0010-debian-patch-09-dummy.diff.patch
+                - patches/0011-debian-patch-10-hurd.diff.patch
+                - patches/0012-debian-patch-11-transfer-timeout.diff.patch
+                - patches/0013-debian-patch-12-ac_prog_cxx.diff.patch
+                - patches/0014-linux.c-error-Fix-snprintf-buffer-sizes.patch
+      config-opts:
+          - --prefix=/app/extensions/oesenc
 
     - name: iproute
       no-autogen: true


### PR DESCRIPTION
This is against the ci branch.

As heading says. update the libusb bundled with the flatpak plugin to avoid crashes.  The update effectively makes the version used identical to the Debian libusb-0.1.4 package. Debian has applied a multitude  of fixes ot the original sources from 2006..

See also: https://github.com/OpenCPN/plugins/issues/28 