### PR TITLE
flatpak: Update to libusb-0.1.12 + debian patches.

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
@@ -7,13 +7,28 @@ separate-locales: false
 appstream-compose: false
 modules:
     - name: libusb
-      no-autogen: true
       sources:
           - type: archive
-            url: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/0.1.6/libusb-0.1.6.tar.gz
-            sha256: 0bafb64bfc41da07ba24c80ee86f57d43c15334e6ff593f806fc331ff8a19571
-      make-install-args:
-          - prefix=/app/extensions/oesenc
+            url: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/0.1.12/libusb-0.1.12.tar.gz
+            sha256: 37f6f7d9de74196eb5fc0bbe0aea9b5c939de7f500acba3af6fd643f3b538b44
+          - type: patch
+            paths:
+                - patches/0001-debian-patch-00-packed.diff.patch
+                - patches/0002-debian-patch-01-ansi.diff.patch
+                - patches/0003-debian-patch-02-usbpp.diff.patch
+                - patches/0004-debian-patch-03-const-buffers.diff.patch
+                - patches/0005-debian-patch-04-infinite-loop.diff.patch
+                - patches/0006-debian-patch-05-emdebian_libs.diff.patch
+                - patches/0007-debian-patch-06-bsd.diff.patch
+                - patches/0008-debian-patch-07-altsetting_alloc.diff.patch
+                - patches/0009-debian-patch-08-bus_location.diff.patch
+                - patches/0010-debian-patch-09-dummy.diff.patch
+                - patches/0011-debian-patch-10-hurd.diff.patch
+                - patches/0012-debian-patch-11-transfer-timeout.diff.patch
+                - patches/0013-debian-patch-12-ac_prog_cxx.diff.patch
+                - patches/0014-linux.c-error-Fix-snprintf-buffer-sizes.patch
+      config-opts:
+          - --prefix=/app/extensions/oesenc
 
     - name: iproute
       no-autogen: true

--- a/flatpak/patches/0001-debian-patch-00-packed.diff.patch
+++ b/flatpak/patches/0001-debian-patch-00-packed.diff.patch
@@ -1,0 +1,60 @@
+From db9833c345d4b41f7e2e1004f44852c8839a9381 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:14:31 +0100
+Subject: [PATCH 01/14] debian patch  00 -- packed.diff.
+
+---
+ usb.h.in | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/usb.h.in b/usb.h.in
+index 443c7c0..7422b30 100644
+--- a/usb.h.in
++++ b/usb.h.in
+@@ -66,14 +66,14 @@
+ struct usb_descriptor_header {
+ 	u_int8_t  bLength;
+ 	u_int8_t  bDescriptorType;
+-};
++} __attribute__ ((packed));
+ 
+ /* String descriptor */
+ struct usb_string_descriptor {
+ 	u_int8_t  bLength;
+ 	u_int8_t  bDescriptorType;
+ 	u_int16_t wData[1];
+-};
++} __attribute__ ((packed));
+ 
+ /* HID descriptor */
+ struct usb_hid_descriptor {
+@@ -85,7 +85,7 @@ struct usb_hid_descriptor {
+ 	/* u_int8_t  bReportDescriptorType; */
+ 	/* u_int16_t wDescriptorLength; */
+ 	/* ... */
+-};
++} __attribute__ ((packed));
+ 
+ /* Endpoint descriptor */
+ #define USB_MAXENDPOINTS	32
+@@ -172,7 +172,7 @@ struct usb_device_descriptor {
+ 	u_int8_t  iProduct;
+ 	u_int8_t  iSerialNumber;
+ 	u_int8_t  bNumConfigurations;
+-};
++} __attribute__ ((packed));
+ 
+ struct usb_ctrl_setup {
+ 	u_int8_t  bRequestType;
+@@ -180,7 +180,7 @@ struct usb_ctrl_setup {
+ 	u_int16_t wValue;
+ 	u_int16_t wIndex;
+ 	u_int16_t wLength;
+-};
++} __attribute__ ((packed));
+ 
+ /*
+  * Standard requests
+-- 
+2.21.0
+

--- a/flatpak/patches/0002-debian-patch-01-ansi.diff.patch
+++ b/flatpak/patches/0002-debian-patch-01-ansi.diff.patch
@@ -1,0 +1,202 @@
+From 540844d937df2231b3b0821193b8e4db8b3f9920 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:15:04 +0100
+Subject: [PATCH 02/14] debian patch  01 -- ansi.diff
+
+---
+ usb.h.in | 118 ++++++++++++++++++++++++++++---------------------------
+ 1 file changed, 60 insertions(+), 58 deletions(-)
+
+diff --git a/usb.h.in b/usb.h.in
+index 7422b30..794cfae 100644
+--- a/usb.h.in
++++ b/usb.h.in
+@@ -13,8 +13,10 @@
+ 
+ #include <unistd.h>
+ #include <stdlib.h>
++#include <stdint.h>
+ #include <limits.h>
+ 
++#include <sys/param.h>
+ #include <dirent.h>
+ 
+ /*
+@@ -64,40 +66,40 @@
+ 
+ /* All standard descriptors have these 2 fields in common */
+ struct usb_descriptor_header {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
+ } __attribute__ ((packed));
+ 
+ /* String descriptor */
+ struct usb_string_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int16_t wData[1];
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint16_t wData[1];
+ } __attribute__ ((packed));
+ 
+ /* HID descriptor */
+ struct usb_hid_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int16_t bcdHID;
+-	u_int8_t  bCountryCode;
+-	u_int8_t  bNumDescriptors;
+-	/* u_int8_t  bReportDescriptorType; */
+-	/* u_int16_t wDescriptorLength; */
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint16_t bcdHID;
++	uint8_t  bCountryCode;
++	uint8_t  bNumDescriptors;
++	/* uint8_t  bReportDescriptorType; */
++	/* uint16_t wDescriptorLength; */
+ 	/* ... */
+ } __attribute__ ((packed));
+ 
+ /* Endpoint descriptor */
+ #define USB_MAXENDPOINTS	32
+ struct usb_endpoint_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int8_t  bEndpointAddress;
+-	u_int8_t  bmAttributes;
+-	u_int16_t wMaxPacketSize;
+-	u_int8_t  bInterval;
+-	u_int8_t  bRefresh;
+-	u_int8_t  bSynchAddress;
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint8_t  bEndpointAddress;
++	uint8_t  bmAttributes;
++	uint16_t wMaxPacketSize;
++	uint8_t  bInterval;
++	uint8_t  bRefresh;
++	uint8_t  bSynchAddress;
+ 
+ 	unsigned char *extra;	/* Extra descriptors */
+ 	int extralen;
+@@ -115,15 +117,15 @@ struct usb_endpoint_descriptor {
+ /* Interface descriptor */
+ #define USB_MAXINTERFACES	32
+ struct usb_interface_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int8_t  bInterfaceNumber;
+-	u_int8_t  bAlternateSetting;
+-	u_int8_t  bNumEndpoints;
+-	u_int8_t  bInterfaceClass;
+-	u_int8_t  bInterfaceSubClass;
+-	u_int8_t  bInterfaceProtocol;
+-	u_int8_t  iInterface;
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint8_t  bInterfaceNumber;
++	uint8_t  bAlternateSetting;
++	uint8_t  bNumEndpoints;
++	uint8_t  bInterfaceClass;
++	uint8_t  bInterfaceSubClass;
++	uint8_t  bInterfaceProtocol;
++	uint8_t  iInterface;
+ 
+ 	struct usb_endpoint_descriptor *endpoint;
+ 
+@@ -141,14 +143,14 @@ struct usb_interface {
+ /* Configuration descriptor information.. */
+ #define USB_MAXCONFIG		8
+ struct usb_config_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int16_t wTotalLength;
+-	u_int8_t  bNumInterfaces;
+-	u_int8_t  bConfigurationValue;
+-	u_int8_t  iConfiguration;
+-	u_int8_t  bmAttributes;
+-	u_int8_t  MaxPower;
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint16_t wTotalLength;
++	uint8_t  bNumInterfaces;
++	uint8_t  bConfigurationValue;
++	uint8_t  iConfiguration;
++	uint8_t  bmAttributes;
++	uint8_t  MaxPower;
+ 
+ 	struct usb_interface *interface;
+ 
+@@ -158,28 +160,28 @@ struct usb_config_descriptor {
+ 
+ /* Device descriptor */
+ struct usb_device_descriptor {
+-	u_int8_t  bLength;
+-	u_int8_t  bDescriptorType;
+-	u_int16_t bcdUSB;
+-	u_int8_t  bDeviceClass;
+-	u_int8_t  bDeviceSubClass;
+-	u_int8_t  bDeviceProtocol;
+-	u_int8_t  bMaxPacketSize0;
+-	u_int16_t idVendor;
+-	u_int16_t idProduct;
+-	u_int16_t bcdDevice;
+-	u_int8_t  iManufacturer;
+-	u_int8_t  iProduct;
+-	u_int8_t  iSerialNumber;
+-	u_int8_t  bNumConfigurations;
++	uint8_t  bLength;
++	uint8_t  bDescriptorType;
++	uint16_t bcdUSB;
++	uint8_t  bDeviceClass;
++	uint8_t  bDeviceSubClass;
++	uint8_t  bDeviceProtocol;
++	uint8_t  bMaxPacketSize0;
++	uint16_t idVendor;
++	uint16_t idProduct;
++	uint16_t bcdDevice;
++	uint8_t  iManufacturer;
++	uint8_t  iProduct;
++	uint8_t  iSerialNumber;
++	uint8_t  bNumConfigurations;
+ } __attribute__ ((packed));
+ 
+ struct usb_ctrl_setup {
+-	u_int8_t  bRequestType;
+-	u_int8_t  bRequest;
+-	u_int16_t wValue;
+-	u_int16_t wIndex;
+-	u_int16_t wLength;
++	uint8_t  bRequestType;
++	uint8_t  bRequest;
++	uint16_t wValue;
++	uint16_t wIndex;
++	uint16_t wLength;
+ } __attribute__ ((packed));
+ 
+ /*
+@@ -250,7 +252,7 @@ struct usb_device {
+ 
+   void *dev;		/* Darwin support */
+ 
+-  u_int8_t devnum;
++  uint8_t devnum;
+ 
+   unsigned char num_children;
+   struct usb_device **children;
+@@ -262,7 +264,7 @@ struct usb_bus {
+   char dirname[PATH_MAX + 1];
+ 
+   struct usb_device *devices;
+-  u_int32_t location;
++  uint32_t location;
+ 
+   struct usb_device *root_dev;
+ };
+-- 
+2.21.0
+

--- a/flatpak/patches/0003-debian-patch-02-usbpp.diff.patch
+++ b/flatpak/patches/0003-debian-patch-02-usbpp.diff.patch
@@ -1,0 +1,25 @@
+From 275d621d66740737594788a7fc0219fbd8168721 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:15:38 +0100
+Subject: [PATCH 03/14] debian patch  02 -- usbpp.diff
+
+---
+ usbpp.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/usbpp.h b/usbpp.h
+index abda64f..423b59d 100644
+--- a/usbpp.h
++++ b/usbpp.h
+@@ -54,7 +54,7 @@ namespace USB {
+ 		 * \returns the number of bytes sent, or a negative value on
+ 		 * failure
+ 		 */
+-		int bulkWrite(QByteArray message, int timeout = 100);
++		int bulkWrite(unsigned char* message, int timeout = 100);
+ 		
+ 		/**
+ 		 * \brief Bulk read
+-- 
+2.21.0
+

--- a/flatpak/patches/0004-debian-patch-03-const-buffers.diff.patch
+++ b/flatpak/patches/0004-debian-patch-03-const-buffers.diff.patch
@@ -1,0 +1,118 @@
+From 574b3512125992665e0d61abf4d7612eebf20d3b Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:16:11 +0100
+Subject: [PATCH 04/14] debian patch  03  -- const buffers.diff
+
+---
+ bsd.c    | 4 ++--
+ darwin.c | 6 +++---
+ linux.c  | 8 ++++----
+ usb.h.in | 4 ++--
+ 4 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/bsd.c b/bsd.c
+index e634867..09d401d 100644
+--- a/bsd.c
++++ b/bsd.c
+@@ -279,7 +279,7 @@ static int ensure_ep_open(usb_dev_handle *dev, int ep, int mode)
+   return info->ep_fd[ep];
+ }
+ 
+-int usb_bulk_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_bulk_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+                    int timeout)
+ {
+   int fd, ret;
+@@ -358,7 +358,7 @@ int usb_bulk_read(usb_dev_handle *dev, int ep, char *bytes, int size,
+   return ret;
+ }
+ 
+-int usb_interrupt_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_interrupt_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+                         int timeout)
+ {
+   int fd, ret, sent = 0;
+diff --git a/darwin.c b/darwin.c
+index 6f90ecc..d58fa79 100644
+--- a/darwin.c
++++ b/darwin.c
+@@ -871,7 +871,7 @@ static int usb_bulk_transfer (usb_dev_handle *dev, int ep, char *bytes, int size
+   return rw_arg.io_size;
+ }
+ 
+-int usb_bulk_write(usb_dev_handle *dev, int ep, char *bytes, int size, int timeout)
++int usb_bulk_write(usb_dev_handle *dev, int ep, const char *bytes, int size, int timeout)
+ {
+   int result;
+   rw_async_to_func_t to_func = NULL;
+@@ -886,7 +886,7 @@ int usb_bulk_write(usb_dev_handle *dev, int ep, char *bytes, int size, int timeo
+   to_func = (*(device->interface))->WritePipeAsyncTO;
+ #endif
+ 
+-  if ((result = usb_bulk_transfer (dev, ep, bytes, size, timeout,
++  if ((result = usb_bulk_transfer (dev, ep, (char *) bytes, size, timeout,
+ 				   (*(device->interface))->WritePipeAsync, to_func)) < 0)
+     USB_ERROR_STR (result, "usb_bulk_write: An error occured during write (see messages above)");
+   
+@@ -918,7 +918,7 @@ int usb_bulk_read(usb_dev_handle *dev, int ep, char *bytes, int size, int timeou
+ }
+ 
+ /* interrupt endpoints seem to be treated just like any other endpoint under OSX/Darwin */
+-int usb_interrupt_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_interrupt_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+ 	int timeout)
+ {
+   return usb_bulk_write (dev, ep, bytes, size, timeout);
+diff --git a/linux.c b/linux.c
+index 3a1ce0c..43cfaf8 100644
+--- a/linux.c
++++ b/linux.c
+@@ -277,11 +277,11 @@ restart:
+   return bytesdone;
+ }
+ 
+-int usb_bulk_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_bulk_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+ 	int timeout)
+ {
+   /* Ensure the endpoint address is correct */
+-  return usb_urb_transfer(dev, ep, USB_URB_TYPE_BULK, bytes, size,
++  return usb_urb_transfer(dev, ep, USB_URB_TYPE_BULK, (char *)bytes, size,
+ 		timeout);
+ }
+ 
+@@ -299,11 +299,11 @@ int usb_bulk_read(usb_dev_handle *dev, int ep, char *bytes, int size,
+  * 2.5 HCDs yet) don't handle multi-packet Interrupt transfers. So we need
+  * to lookup the endpoint packet size and packetize appropriately here.
+  */
+-int usb_interrupt_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_interrupt_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+ 	int timeout)
+ {
+   /* Ensure the endpoint address is correct */
+-  return usb_urb_transfer(dev, ep, USB_URB_TYPE_INTERRUPT, bytes, size,
++  return usb_urb_transfer(dev, ep, USB_URB_TYPE_INTERRUPT, (char *)bytes, size,
+ 		timeout);
+ }
+ 
+diff --git a/usb.h.in b/usb.h.in
+index 794cfae..99a7be7 100644
+--- a/usb.h.in
++++ b/usb.h.in
+@@ -296,11 +296,11 @@ int usb_get_descriptor(usb_dev_handle *udev, unsigned char type,
+ 	unsigned char index, void *buf, int size);
+ 
+ /* <arch>.c */
+-int usb_bulk_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_bulk_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+ 	int timeout);
+ int usb_bulk_read(usb_dev_handle *dev, int ep, char *bytes, int size,
+ 	int timeout);
+-int usb_interrupt_write(usb_dev_handle *dev, int ep, char *bytes, int size,
++int usb_interrupt_write(usb_dev_handle *dev, int ep, const char *bytes, int size,
+         int timeout);
+ int usb_interrupt_read(usb_dev_handle *dev, int ep, char *bytes, int size,
+         int timeout);
+-- 
+2.21.0
+

--- a/flatpak/patches/0005-debian-patch-04-infinite-loop.diff.patch
+++ b/flatpak/patches/0005-debian-patch-04-infinite-loop.diff.patch
@@ -1,0 +1,41 @@
+From f7a46ef6dd627ab0a2aeab5fcfb7845eb93ba4e6 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:16:36 +0100
+Subject: [PATCH 05/14] debian patch  04 -- infinite loop.diff
+
+---
+ linux.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/linux.c b/linux.c
+index 43cfaf8..a7128ea 100644
+--- a/linux.c
++++ b/linux.c
+@@ -213,15 +213,21 @@ static int usb_urb_transfer(usb_dev_handle *dev, int ep, int urbtype,
+       return ret;
+     }
+ 
+-    FD_ZERO(&writefds);
+-    FD_SET(dev->fd, &writefds);
+-
+ restart:
+     waiting = 1;
+     context = NULL;
+     while (!urb.usercontext && ((ret = ioctl(dev->fd, IOCTL_USB_REAPURBNDELAY, &context)) == -1) && waiting) {
++      if (ret == -1)
++      {
++        if (errno == ENODEV)
++        {
++          return -ENODEV;
++        }
++      }
+       tv.tv_sec = 0;
+       tv.tv_usec = 1000; // 1 msec
++      FD_ZERO(&writefds);
++      FD_SET(dev->fd, &writefds);
+       select(dev->fd + 1, NULL, &writefds, NULL, &tv); //sub second wait
+ 
+       if (timeout) {
+-- 
+2.21.0
+

--- a/flatpak/patches/0006-debian-patch-05-emdebian_libs.diff.patch
+++ b/flatpak/patches/0006-debian-patch-05-emdebian_libs.diff.patch
@@ -1,0 +1,49 @@
+From 83dc4c91c03cf56ef22af10c97fab79548e489e6 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:17:19 +0100
+Subject: [PATCH 06/14] debian patch 05 -- emdebian_libs.diff
+
+---
+ tests/Makefile.am | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index d9d6102..599dd4b 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -11,25 +11,25 @@ noinst_PROGRAMS = testlibusb descriptor_test id_test find_hubs find_mice \
+ testlibusb_LDADD = $(top_builddir)/libusb.la @OSLIBS@
+ 
+ descriptor_test_SOURCES = descriptor_test.cpp
+-descriptor_test_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++descriptor_test_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ id_test_SOURCES = id_test.cpp
+-id_test_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++id_test_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ find_hubs_SOURCES = find_hubs.cpp
+-find_hubs_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++find_hubs_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ find_mice_SOURCES = find_mice.cpp
+-find_mice_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++find_mice_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ get_resolution_SOURCES = get_resolution.cpp
+-get_resolution_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++get_resolution_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ hub_strings_SOURCES = hub_strings.cpp
+-hub_strings_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++hub_strings_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ driver_name_SOURCES = driver_name.cpp
+-driver_name_LDADD = $(top_builddir)/libusbpp.la @OSLIBS@
++driver_name_LDADD = $(top_builddir)/libusbpp.la $(top_builddir)/libusb.la @OSLIBS@
+ 
+ TESTS = testlibusb descriptor_test id_test find_hubs find_mice \
+ 		get_resolution hub_strings $(OS_SPECIFIC)
+-- 
+2.21.0
+

--- a/flatpak/patches/0007-debian-patch-06-bsd.diff.patch
+++ b/flatpak/patches/0007-debian-patch-06-bsd.diff.patch
@@ -1,0 +1,41 @@
+From cd6fd2d2b76b3dc6a86193c72152c86696236c8f Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:17:40 +0100
+Subject: [PATCH 07/14] debian patch 06 -- bsd.diff.
+
+---
+ bsd.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/bsd.c b/bsd.c
+index 09d401d..844bdf0 100644
+--- a/bsd.c
++++ b/bsd.c
+@@ -39,14 +39,22 @@
+ #include <sys/time.h>
+ #include <sys/ioctl.h>
+ 
+-#include <dev/usb/usb.h>
++#include "freebsd-usb.h"
+ 
+ #include "usbi.h"
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+ 
+-#ifdef HAVE_OLD_DEV_USB_USB_H
++/*
++ * Since the Debian version includes "freebsd-usb.h" instead of
++ * <dev/usb/usb.h>, the API provided by the latter file does not matter. The
++ * configure check gives false positives as of 2012, but rather than fixing a
++ * check for something we don't use anyway, just unconditionally skip those
++ * definitions.
++ * #ifdef HAVE_OLD_DEV_USB_USB_H
++ */
++#if 0
+ /*
+  * It appears some of the BSD's (OpenBSD atleast) have switched over to a
+  * new naming convention, so we setup some macro's for backward
+-- 
+2.21.0
+

--- a/flatpak/patches/0008-debian-patch-07-altsetting_alloc.diff.patch
+++ b/flatpak/patches/0008-debian-patch-07-altsetting_alloc.diff.patch
@@ -1,0 +1,46 @@
+From 9da98c51514ab1f95dd0c187fad404bdb747ed31 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:18:15 +0100
+Subject: [PATCH 08/14] debian patch 07 -- altsetting_alloc.diff
+
+---
+ descriptors.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/descriptors.c b/descriptors.c
+index 0146a82..ac1dd82 100644
+--- a/descriptors.c
++++ b/descriptors.c
+@@ -177,6 +177,7 @@ static int usb_parse_interface(struct usb_interface *interface,
+     }
+ 
+     ifp = interface->altsetting + interface->num_altsetting;
++    memset(ifp, 0, sizeof(struct usb_interface_descriptor));
+     interface->num_altsetting++;
+ 
+     usb_parse_descriptor(buffer, "bbbbbbbbb", ifp);
+@@ -219,10 +220,7 @@ static int usb_parse_interface(struct usb_interface *interface,
+     /* Copy any unknown descriptors into a storage area for */
+     /*  drivers to later parse */
+     len = (int)(buffer - begin);
+-    if (!len) {
+-      ifp->extra = NULL;
+-      ifp->extralen = 0;
+-    } else {
++    if (len) {
+       ifp->extra = malloc(len);
+       if (!ifp->extra) {
+         if (usb_debug >= 1)
+@@ -277,8 +275,7 @@ static int usb_parse_interface(struct usb_interface *interface,
+         parsed += retval;
+         size -= retval;
+       }
+-    } else
+-      ifp->endpoint = NULL;
++    }
+ 
+     /* We check to see if it's an alternate to this one */
+     ifp = (struct usb_interface_descriptor *)buffer;
+-- 
+2.21.0
+

--- a/flatpak/patches/0009-debian-patch-08-bus_location.diff.patch
+++ b/flatpak/patches/0009-debian-patch-08-bus_location.diff.patch
@@ -1,0 +1,24 @@
+From dc8358d0ab41b299a4503000213b60c5a91c7004 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:18:42 +0100
+Subject: [PATCH 09/14] debian patch 08 bus_location.diff.
+
+---
+ linux.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/linux.c b/linux.c
+index a7128ea..329c8f0 100644
+--- a/linux.c
++++ b/linux.c
+@@ -355,6 +355,7 @@ int usb_os_find_busses(struct usb_bus **busses)
+ 
+     strncpy(bus->dirname, entry->d_name, sizeof(bus->dirname) - 1);
+     bus->dirname[sizeof(bus->dirname) - 1] = 0;
++    bus->location = atoi(bus->dirname);
+ 
+     LIST_ADD(fbus, bus);
+ 
+-- 
+2.21.0
+

--- a/flatpak/patches/0010-debian-patch-09-dummy.diff.patch
+++ b/flatpak/patches/0010-debian-patch-09-dummy.diff.patch
@@ -1,0 +1,107 @@
+From 0757091a1249bbc0881169a11d400ada3f727208 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:19:05 +0100
+Subject: [PATCH 10/14] debian patch 09 -- dummy.diff.
+
+---
+ Makefile.am  |  4 ++--
+ configure.in | 17 +++++++++++++++--
+ 2 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index cab1309..57196e5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -17,7 +17,7 @@ libusb-config: libusb-config.in
+ EXTRA_DIST = LICENSE libusb.spec.in libusb.spec libusb-config.in README.in README \
+              INSTALL.libusb.in INSTALL.libusb Doxyfile apidocs/header.html \
+              apidocs/footer.html apidocs/doxygen.css apidocs/doxygen.png libusb.pc.in
+-EXTRA_libusb_la_SOURCE = linux.c linux.h bsd.c darwin.c
++EXTRA_libusb_la_SOURCE = linux.c linux.h bsd.c darwin.c dummy.c
+ 
+ lib_LTLIBRARIES = libusb.la libusbpp.la
+ 
+@@ -36,7 +36,7 @@ LDADDS = -Wl,-framework -Wl,IOKit -Wl,-framework -Wl,CoreFoundation -Wl,-prebind
+ PREBIND_FLAGS=-Wl,-seg1addr,0x01666000
+ PREBIND_FLAGSPP=-Wl,-seg1addr,0x01676000
+ else
+-OS_SUPPORT = 
++OS_SUPPORT = dummy.c
+ endif
+ endif
+ endif
+diff --git a/configure.in b/configure.in
+index 331cec6..b0aed4e 100644
+--- a/configure.in
++++ b/configure.in
+@@ -11,6 +11,7 @@ AH_TOP(
+ #undef LINUX_API
+ #undef BSD_API
+ #undef DARWIN_API
++#undef DUMMY_API
+ 
+ #undef HAVE_OLD_DEV_USB_USB_H
+ 
+@@ -89,6 +90,7 @@ dnl AC_CANONICAL_HOST
+ LINUX_API=0
+ DARWIN_API=0
+ BSD_API=0
++DUMMY_API=0
+ 
+ AC_MSG_CHECKING(for what USB OS support)
+ case $host in
+@@ -96,6 +98,7 @@ case $host in
+     AC_DEFINE(LINUX_API, 1)
+     AC_DEFINE(BSD_API, 0)
+     AC_DEFINE(DARWIN_API, 0)
++    AC_DEFINE(DUMMY_API, 0)
+     LINUX_API=1
+     os_support=linux
+     AC_MSG_RESULT(Linux)
+@@ -105,6 +108,7 @@ case $host in
+     AC_DEFINE(BSD_API, 1)
+     AC_DEFINE(LINUX_API, 0)
+     AC_DEFINE(DARWIN_API, 0)
++    AC_DEFINE(DUMMY_API, 0)
+     BSD_API=1
+     os_support=bsd
+     AC_MSG_RESULT(FreeBSD, OpenBSD and/or NetBSD)
+@@ -114,24 +118,33 @@ case $host in
+     AC_DEFINE(DARWIN_API, 1) 
+     AC_DEFINE(LINUX_API, 0)
+     AC_DEFINE(BSD_API, 0)
++    AC_DEFINE(DUMMY_API, 0)
+     DARWIN_API=1
+     os_support=darwin
+     AC_MSG_RESULT(Darwin and/or MacOS 10)
+     OSLIBS="-Wl,-framework -Wl,IOKit -Wl,-framework -Wl,CoreFoundation -Wl,-prebind"
+     ;;
+   *)
+-    AC_MSG_RESULT(unknown operating system)
+-    AC_MSG_ERROR(libusb does not support compiling for $host)
++    AC_DEFINE(DARWIN_API, 0) 
++    AC_DEFINE(LINUX_API, 0)
++    AC_DEFINE(BSD_API, 0)
++    AC_DEFINE(DUMMY_API, 1)
++    DUMMY_API=1
++    os_support=dummy
++    AC_MSG_RESULT(unknown operating system $host)
++    OSLIBS=""
+     ;;
+ esac
+ 
+ AC_SUBST(DARWIN_API)
+ AC_SUBST(LINUX_API)
+ AC_SUBST(BSD_API)
++AC_SUBST(DUMMY_API)
+ 
+ AM_CONDITIONAL(LINUX_API, test "$os_support" = "linux")
+ AM_CONDITIONAL(BSD_API, test "$os_support" = "bsd")
+ AM_CONDITIONAL(DARWIN_API, test "$os_support" = "darwin")
++AM_CONDITIONAL(DUMMY_API, test "$os_support" = "dummy")
+ 
+ AC_SUBST(OSLIBS)
+ 
+-- 
+2.21.0
+

--- a/flatpak/patches/0011-debian-patch-10-hurd.diff.patch
+++ b/flatpak/patches/0011-debian-patch-10-hurd.diff.patch
@@ -1,0 +1,42 @@
+From 83d095bdbfaa7d0e58ea3db605707e4d6e33f019 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:19:27 +0100
+Subject: [PATCH 11/14] debian patch 10 -- hurd.diff.
+
+---
+ usb.h.in | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/usb.h.in b/usb.h.in
+index 99a7be7..ce51b5f 100644
+--- a/usb.h.in
++++ b/usb.h.in
+@@ -240,10 +240,15 @@ struct usb_bus;
+  * we must only add entries to the end of this structure. NEVER delete or
+  * move members and only change types if you really know what you're doing.
+  */
++#ifdef PATH_MAX
++#define LIBUSB_PATH_MAX PATH_MAX
++#else
++#define LIBUSB_PATH_MAX 4096
++#endif
+ struct usb_device {
+   struct usb_device *next, *prev;
+ 
+-  char filename[PATH_MAX + 1];
++  char filename[LIBUSB_PATH_MAX + 1];
+ 
+   struct usb_bus *bus;
+ 
+@@ -261,7 +266,7 @@ struct usb_device {
+ struct usb_bus {
+   struct usb_bus *next, *prev;
+ 
+-  char dirname[PATH_MAX + 1];
++  char dirname[LIBUSB_PATH_MAX + 1];
+ 
+   struct usb_device *devices;
+   uint32_t location;
+-- 
+2.21.0
+

--- a/flatpak/patches/0012-debian-patch-11-transfer-timeout.diff.patch
+++ b/flatpak/patches/0012-debian-patch-11-transfer-timeout.diff.patch
@@ -1,0 +1,54 @@
+From 8e715be0539a4d9211a561f5a1f01740f295601e Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:19:58 +0100
+Subject: [PATCH 12/14] debian patch 11 -- transfer timeout.diff.
+
+---
+ linux.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/linux.c b/linux.c
+index 329c8f0..3b2b9a8 100644
+--- a/linux.c
++++ b/linux.c
+@@ -190,6 +190,8 @@ static int usb_urb_transfer(usb_dev_handle *dev, int ep, int urbtype,
+     tv_ref.tv_sec++;
+   }
+ 
++  waiting = 1;
++
+   do {
+     fd_set writefds;
+ 
+@@ -214,7 +216,6 @@ static int usb_urb_transfer(usb_dev_handle *dev, int ep, int urbtype,
+     }
+ 
+ restart:
+-    waiting = 1;
+     context = NULL;
+     while (!urb.usercontext && ((ret = ioctl(dev->fd, IOCTL_USB_REAPURBNDELAY, &context)) == -1) && waiting) {
+       if (ret == -1)
+@@ -243,6 +244,7 @@ restart:
+     if (context && context != &urb) {
+       context->usercontext = URB_USERCONTEXT_COOKIE;
+       /* We need to restart since we got a successful URB, but not ours */
++      waiting = 1;
+       goto restart;
+     }
+ 
+@@ -255,10 +257,10 @@ restart:
+       USB_ERROR_STR(-errno, "error reaping URB: %s", strerror(errno));
+ 
+     bytesdone += urb.actual_length;
+-  } while ((ret == 0 || urb.usercontext) && bytesdone < size && urb.actual_length == requested);
++  } while ((ret == 0 || urb.usercontext) && bytesdone < size && urb.actual_length == requested && waiting);
+ 
+   /* If the URB didn't complete in success or error, then let's unlink it */
+-  if (ret < 0 && !urb.usercontext) {
++  if ((ret < 0 && !urb.usercontext) || (!waiting && bytesdone < size)) {
+     int rc;
+ 
+     if (!waiting)
+-- 
+2.21.0
+

--- a/flatpak/patches/0013-debian-patch-12-ac_prog_cxx.diff.patch
+++ b/flatpak/patches/0013-debian-patch-12-ac_prog_cxx.diff.patch
@@ -1,0 +1,24 @@
+From 6e952601b4fc6834ccbf355abd5520e5a75e626b Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:20:54 +0100
+Subject: [PATCH 13/14] debian patch 12 -- ac_prog_cxx.diff.
+
+---
+ configure.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.in b/configure.in
+index b0aed4e..340facd 100644
+--- a/configure.in
++++ b/configure.in
+@@ -162,6 +162,7 @@ if test "x$enable_debug" = "xyes"; then
+ fi
+ 
+ # Checks for programs.
++AC_PROG_CXX
+ AC_LANG_CPLUSPLUS
+ AC_PROG_CC
+ AM_PROG_CC_C_O
+-- 
+2.21.0
+

--- a/flatpak/patches/0014-linux.c-error-Fix-snprintf-buffer-sizes.patch
+++ b/flatpak/patches/0014-linux.c-error-Fix-snprintf-buffer-sizes.patch
@@ -1,0 +1,87 @@
+From 78505b97d4fc82a769f434d0e51d364acfff7ec9 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sat, 22 Feb 2020 11:50:17 +0100
+Subject: [PATCH 14/14] linux.c, error: Fix snprintf buffer sizes.
+
+---
+ error.c |  2 +-
+ error.h |  2 +-
+ linux.c | 12 ++++++------
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/error.c b/error.c
+index f7d496d..cc96b41 100644
+--- a/error.c
++++ b/error.c
+@@ -12,7 +12,7 @@
+ #include "usb.h"
+ #include "error.h"
+ 
+-char usb_error_str[1024] = "";
++char usb_error_str[4*PATH_MAX] = "";
+ int usb_error_errno = 0;
+ usb_error_type_t usb_error_type = USB_ERROR_TYPE_NONE;
+ 
+diff --git a/error.h b/error.h
+index 173e6fd..38890f4 100644
+--- a/error.h
++++ b/error.h
+@@ -7,7 +7,7 @@ typedef enum {
+   USB_ERROR_TYPE_ERRNO,
+ } usb_error_type_t;
+ 
+-extern char usb_error_str[1024];
++extern char usb_error_str[4*PATH_MAX];
+ extern int usb_error_errno;
+ extern usb_error_type_t usb_error_type;
+ 
+diff --git a/linux.c b/linux.c
+index 3b2b9a8..e4cc74b 100644
+--- a/linux.c
++++ b/linux.c
+@@ -22,10 +22,10 @@ static char usb_path[PATH_MAX + 1] = "";
+ 
+ static int device_open(struct usb_device *dev)
+ {
+-  char filename[PATH_MAX + 1];
++  char filename[3*PATH_MAX + 4];
+   int fd;
+ 
+-  snprintf(filename, sizeof(filename) - 1, "%s/%s/%s",
++  snprintf(filename, 3*PATH_MAX + 3, "%s/%s/%s",
+     usb_path, dev->bus->dirname, dev->filename);
+ 
+   fd = open(filename, O_RDWR);
+@@ -377,9 +377,9 @@ int usb_os_find_devices(struct usb_bus *bus, struct usb_device **devices)
+   struct usb_device *fdev = NULL;
+   DIR *dir;
+   struct dirent *entry;
+-  char dirpath[PATH_MAX + 1];
++  char dirpath[2*PATH_MAX + 3];
+ 
+-  snprintf(dirpath, PATH_MAX, "%s/%s", usb_path, bus->dirname);
++  snprintf(dirpath, 2*PATH_MAX + 2, "%s/%s", usb_path, bus->dirname);
+ 
+   dir = opendir(dirpath);
+   if (!dir)
+@@ -388,7 +388,7 @@ int usb_os_find_devices(struct usb_bus *bus, struct usb_device **devices)
+ 
+   while ((entry = readdir(dir)) != NULL) {
+     unsigned char device_desc[DEVICE_DESC_LENGTH];
+-    char filename[PATH_MAX + 1];
++    char filename[3*PATH_MAX + 3];
+     struct usb_device *dev;
+     struct usb_connectinfo connectinfo;
+     int i, fd, ret;
+@@ -408,7 +408,7 @@ int usb_os_find_devices(struct usb_bus *bus, struct usb_device **devices)
+     strncpy(dev->filename, entry->d_name, sizeof(dev->filename) - 1);
+     dev->filename[sizeof(dev->filename) - 1] = 0;
+ 
+-    snprintf(filename, sizeof(filename) - 1, "%s/%s", dirpath, entry->d_name);
++    snprintf(filename, 3*PATH_MAX + 2, "%s/%s", dirpath, entry->d_name);
+     fd = open(filename, O_RDWR);
+     if (fd < 0) {
+       fd = open(filename, O_RDONLY);
+-- 
+2.21.0
+


### PR DESCRIPTION
This is a reffreshed PR against the ci branch, this time including patches.

The patch updates the libusb bundled in the flatpak build to 0.1.12 + all patches in the debian libusb-0.1.4 package. 