### PR TITLE
Arm64 build

### DIFF
--- a/cmake/PluginPackage.cmake
+++ b/cmake/PluginPackage.cmake
@@ -82,7 +82,11 @@ IF(UNIX AND NOT APPLE)
 
 
   IF (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    SET (ARCH "armhf")
+    IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
+      SET (ARCH "arm64")
+    ELSE ()
+      SET (ARCH "armhf")
+    ENDIF ()
     # don't bother with rpm on armhf
     SET(CPACK_GENERATOR "DEB;TGZ")
   ELSE ()

--- a/src/oesenc_pi.cpp
+++ b/src/oesenc_pi.cpp
@@ -3836,6 +3836,7 @@ void androidGetDeviceName()
 bool IsDongleAvailable()
 {
 #ifndef __OCPN__ANDROID__    
+#ifndef OCPN_ARM64  // SDlock is not supported for ARM64
     wxString cmd = g_sencutil_bin;
     cmd += _T(" -s ");                  // Available?
 
@@ -3873,6 +3874,7 @@ bool IsDongleAvailable()
     }
 
     //g_sencutil_bin.Clear();
+#endif
 #endif
     
     return false;

--- a/src/oesenc_pi.cpp
+++ b/src/oesenc_pi.cpp
@@ -3836,7 +3836,7 @@ void androidGetDeviceName()
 bool IsDongleAvailable()
 {
 #ifndef __OCPN__ANDROID__    
-#ifndef OCPN_ARM64  // SDlock is not supported for ARM64
+#ifndef OCPN_ARM64  // SGlock is not supported for ARM64
     wxString cmd = g_sencutil_bin;
     cmd += _T(" -s ");                  // Available?
 


### PR DESCRIPTION
Patch cmake:
cmake sees ARM and builds a package for ARMHF.
for ARM64 this will not work, therefore copy some checks from OpenCPN to build for ARM64.

Fix for #52 


Patch oesenc_pi.cpp:
SGlock is not supported for ARM64, the oeserverd for ARM64 is older than for other platforms.
Some commandline options are missing from the ARM64-version.
Those commandline options break oesenc_pi.

With one IFDEF the faulty check is bypassed, allowing for oesenc_pi to work with FPR.
With the system FPR using o-charts with ARM64 is again possible.
(Actually 2 IFDEF's, the other prevents creating a USB key dongle System ID file and is already present in the code.)

Fix for #56 
Partial fix for issue #55, since SGlock still does not work.