### PR TITLE
PluginSetup: Fix indentation.

### DIFF
--- a/cmake/PluginSetup.cmake
+++ b/cmake/PluginSetup.cmake
@@ -48,17 +48,16 @@ elseif (UNIX)
                     OUTPUT_VARIABLE PKG_TARGET_VERSION
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Generate architecturally uniques names for linux output packages
-if(ARCH MATCHES "arm64")
- set(PKG_TARGET "${PKG_TARGET}-ARM64")
-elseif(ARCH MATCHES "armhf")
- set(PKG_TARGET "${PKG_TARGET}-ARMHF")
-elseif(ARCH MATCHES "i386")
- set(PKG_TARGET "${PKG_TARGET}-i386")
-else ()
- set(PKG_TARGET "${PKG_TARGET}-x86_64")
-endif ()    
-        
+    # Generate architecturally uniques names for linux output packages
+    if(ARCH MATCHES "arm64")
+        set(PKG_TARGET "${PKG_TARGET}-ARM64")
+    elseif(ARCH MATCHES "armhf")
+        set(PKG_TARGET "${PKG_TARGET}-ARMHF")
+    elseif(ARCH MATCHES "i386")
+        set(PKG_TARGET "${PKG_TARGET}-i386")
+    else ()
+        set(PKG_TARGET "${PKG_TARGET}-x86_64")
+    endif ()
 else ()
     set(PKG_TARGET "unknown")
     set(PKG_TARGET_VERSION 1)


### PR DESCRIPTION
The new code generating the architecture-dependent PKG_TARGET is a bit hard to read due to missing indentation. Since there are many eyes on this code, let's fix that.