### PR TITLE
Adapt avnav

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ else ()
 endif ()
 
 IF(NOT WIN32)
- ADD_DEFINITIONS( "-Wall -g -fexceptions -O2 -Wno-unused -fno-strict-aliasing ")
+ ADD_DEFINITIONS( "-Wall -g -fexceptions -Wno-unused -fno-strict-aliasing ")
 
  IF(CMAKE_BUILD_TYPE MATCHES "Debug")
     ADD_DEFINITIONS( " -O0")

--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -33,7 +33,7 @@ IF(NOT MSVC)
   ADD_DEFINITIONS( "-Wall -g -fprofile-arcs -ftest-coverage -fexceptions" )
  ELSE(PROFILING)
 #  ADD_DEFINITIONS( "-Wall -g -fexceptions" )
- ADD_DEFINITIONS( "-Wall -Wno-unused-result -g -O2 -fexceptions" )
+ ADD_DEFINITIONS( "-Wall -Wno-unused-result -g -fexceptions" )
  ENDIF(PROFILING)
 
  IF(NOT APPLE)

--- a/src/ochartShop.cpp
+++ b/src/ochartShop.cpp
@@ -3101,7 +3101,10 @@ bool shopPanel::doSystemNameWizard( bool *bnew )
     if( g_systemName.Len() && (g_systemNameChoiceArray.Index(g_systemName) == wxNOT_FOUND))
         g_systemNameChoiceArray.Insert(g_systemName, 0);
     
-    oeSENCSystemNameSelector dlg( GetOCPNCanvasWindow());
+    wxWindow *canvas=GetOCPNCanvasWindow();
+    if (canvas == NULL) return false;
+    
+    oeSENCSystemNameSelector dlg( canvas);
     
     wxSize dialogSize(500, -1);
     
@@ -3159,7 +3162,10 @@ bool shopPanel::doSystemNameWizard( bool *bnew )
 
 wxString shopPanel::doGetNewSystemName( )
 {
-    oeSENCGETSystemName dlg( GetOCPNCanvasWindow());
+    wxWindow *canvas=GetOCPNCanvasWindow();
+    if (canvas == NULL) return wxEmptyString;
+    
+    oeSENCGETSystemName dlg( canvas);
     
     wxSize dialogSize(500, -1);
     

--- a/src/oesenc_pi.cpp
+++ b/src/oesenc_pi.cpp
@@ -2463,8 +2463,12 @@ Your oeSENC UserKey may be obtained from your chart provider.\n\n"),
          return g_UserKey;
      else
      {
+         wxWindow *canvas=GetOCPNCanvasWindow();
+         if (canvas == NULL) return g_UserKey;
+         
          g_old_UserKey = g_UserKey;
-         SENCGetUserKeyDialog dlg( legendID, GetOCPNCanvasWindow());
+         
+         SENCGetUserKeyDialog dlg( legendID, canvas);
          
          wxSize dialogSize(500, -1);
          
@@ -4204,6 +4208,8 @@ void oesenc_pi_event_handler::OnClearSystemName( wxCommandEvent &event )
 void oesenc_pi_event_handler::OnShowEULA( wxCommandEvent &event )
 {
     ChartSetEULA *CSE;
+    wxWindow *canvas=GetOCPNCanvasWindow();
+    if (canvas == NULL) return;
     
     for(unsigned int i=0 ; i < g_EULAArray.GetCount() ; i++){
         CSE = g_EULAArray.Item(i);
@@ -4211,7 +4217,7 @@ void oesenc_pi_event_handler::OnShowEULA( wxCommandEvent &event )
         file.Replace('!', wxFileName::GetPathSeparator());
         
         if(wxFileExists(file)){
-            oesenc_pi_about *pab = new oesenc_pi_about( GetOCPNCanvasWindow(), file );
+            oesenc_pi_about *pab = new oesenc_pi_about( canvas, file );
             pab->SetOKMode();
             pab->ShowModal();
             pab->Destroy();
@@ -4618,12 +4624,13 @@ bool CheckEULA( void )
     
     if(g_bEULA_OK && g_UserKey.Length())
         return true;
-       
+    wxWindow *canvas=GetOCPNCanvasWindow();
+    if (canvas == NULL) return true;   
     wxString shareLocn =*GetpSharedDataLocation() +
     _T("plugins") + wxFileName::GetPathSeparator() +
     _T("oesenc_pi") + wxFileName::GetPathSeparator();
     
-    oesenc_pi_about *pab = new oesenc_pi_about( GetOCPNCanvasWindow() );
+    oesenc_pi_about *pab = new oesenc_pi_about( canvas );
     pab->ShowModal();
     g_bEULA_OK = (pab->GetReturnCode() == 0);
     
@@ -4690,6 +4697,8 @@ wxString getEULASha1( wxString fileName)
 bool ShowEULA( wxString fileName )
 {
     wxLogMessage(_T("ShowEULA"));
+    wxWindow *canvas=GetOCPNCanvasWindow();
+    if (canvas == NULL) return true;
     
     wxString sha = getEULASha1(fileName);
     
@@ -4703,7 +4712,7 @@ bool ShowEULA( wxString fileName )
     androidHideBusyIcon();
 #endif
     
-    oesenc_pi_about *pab = new oesenc_pi_about( GetOCPNCanvasWindow(), fileName );
+    oesenc_pi_about *pab = new oesenc_pi_about( canvas, fileName );
     pab->ShowModal();
     bool bEULA_OK = (pab->GetReturnCode() == 0);
     


### PR DESCRIPTION
Hi Dave,
as discussed via mail here is a PR to make the plugin robust against GetOCPNCanvasWindow returning NULL for using it with AvNav.
Made some tests with the current beta and functions seemed to work (eula, chartinfo, shop access).
I also included a commit to make the debug compile without -O2 to allow for pi debugging.
But it's independent from the source changes.