### PR TITLE
flatpak: strip excessively large tarball.

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.oesenc.yaml
@@ -12,6 +12,7 @@ modules:
       build-options:
           cflags: -fPIC
           cxxflags: -fPIC -DFLATPAK
+          strip: true
       config-opts:
           - -DPREFIX:PATH=/app/extensions/oesenc
       post-install:


### PR DESCRIPTION
The flatpak tarball is current 7.6M whereas other architectures are
700-800Kb. The reason is the debugging symbols which are not
stripped from the library.

Enclosed patch strips the tarball, bringing it to the same size
as the others. Devs in need of debugging symbols might run into
troubles, but the 7.6 MB price is just to high for this benefit.