### PR TITLE
Migrate to o-charts note 

### DIFF
--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -2,6 +2,10 @@
 
 == OpenCPN Vector Charts
 
+oeSENC is no longer being used or accepted.
+oeSENC and oeRNC users must migrate to using the "o-charts Plugin" please see
+[[https://o-charts.org/manuals/migration.php?lng=en|Migration to O-charts]]
+
 OCPN Vector Charts are licensed and sourced from chart providers like
 Hydrographic Offices. These - non free - charts give OCPN access to
 up-to-date and proven charts for areas where those are not available for


### PR DESCRIPTION
This is not adequate, I think the plugin itself should not be allowed to be downloaded from the website too, if that has not happened, and a note left there as well.